### PR TITLE
Supporting tmpDir option

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ module.exports = {
         limit: 10,
         useCache: true,
         cacheDirName: CACHE_DIR,
-		tmpDir: os.tmpdir()
+        tmpDir: os.tmpdir()
       });
 
       iterate(this.filesSrc, options, done);

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var fs = require('fs');
 var CacheSwap = require('cache-swap');
 var SWAP_CATEGORY = 'linted';
 var CACHE_DIR = 'php-lint';
+var CACHE_TMP_DIR = os.tmpdir();
 
 function testPhp () {
   exec(phpCmd + ' -v', function(err, stdout, stderr) {
@@ -100,7 +101,8 @@ module.exports = {
       callback = options;
       options = {
         useCache: true,
-        cacheDirName: CACHE_DIR
+        cacheDirName: CACHE_DIR,
+        tmpDir: CACHE_TMP_DIR
       };
     }
 
@@ -118,13 +120,14 @@ module.exports = {
     });
   },
 
-  clearCache: function(cacheDirName, callback) {
+  clearCache: function(cacheDirName, tmpDir, callback) {
     if (typeof cacheDirName === 'function') {
       callback = cacheDirName;
       cacheDirName = CACHE_DIR;
+      tmpDir = CACHE_TMP_DIR;
     }
 
-    var cache = new CacheSwap({cacheDirName: cacheDirName, tmpDir: options.tmpDir});
+    var cache = new CacheSwap({cacheDirName: cacheDirName, tmpDir: tmpDir});
     cache.clear(null, callback);
   },
 
@@ -141,7 +144,7 @@ module.exports = {
         limit: 10,
         useCache: true,
         cacheDirName: CACHE_DIR,
-        tmpDir: os.tmpdir()
+        tmpDir: CACHE_TMP_DIR
       });
 
       iterate(this.filesSrc, options, done);

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function lint (path, callback) {
 function iterate (filePaths, options, callback) {
   var swap = null;
   if (options.useCache) {
-    swap = new CacheSwap({cacheDirName: options.cacheDirName});
+    swap = new CacheSwap({cacheDirName: options.cacheDirName, tmpDir: options.tmpDir});
   }
 
   async.eachLimit(filePaths, options.limit, function (filePath, next) {
@@ -110,7 +110,7 @@ module.exports = {
     testPhp();
 
     if (options.useCache) {
-      swap = new CacheSwap({cacheDirName: options.cacheDirName});
+      swap = new CacheSwap({cacheDirName: options.cacheDirName, tmpDir: options.tmpDir});
     }
 
     globby(files, function (err, paths) {
@@ -124,7 +124,7 @@ module.exports = {
       cacheDirName = CACHE_DIR;
     }
 
-    var cache = new CacheSwap({cacheDirName: cacheDirName});
+    var cache = new CacheSwap({cacheDirName: cacheDirName, tmpDir: options.tmpDir});
     cache.clear(null, callback);
   },
 
@@ -140,7 +140,8 @@ module.exports = {
         stderr: true,
         limit: 10,
         useCache: true,
-        cacheDirName: CACHE_DIR
+        cacheDirName: CACHE_DIR,
+		tmpDir: os.tmpdir()
       });
 
       iterate(this.filesSrc, options, done);

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,12 @@ $ npm test
 
 ### Grunt
 
+#### Configure cache directories
+
+This module uses the `cache-swap` module to cache already linted files.
+You can configure the cache directories via the `cacheDirName` and the `tmpDir` options.
+Both options will be passed to the CacheSwap instance when created.
+
 ```js
 module.exports = function(grunt) {
 
@@ -70,7 +76,9 @@ module.exports = function(grunt) {
         limit: 10,
         phpCmd: '/home/scripts/php', // Defaults to php
         stdout: true,
-        stderr: true
+        stderr: true,
+        tmpDir: '/custom/root/folder', // Defaults to os.tmpDir()
+        cacheDirName: 'custom/subfolder' // Defaults to php-lint
       },
       files: 'src/**/*.php'
     }


### PR DESCRIPTION
CacheSwap has an option called 'tmpDir' which defines the root of the temporary directory where the cache files will be saved to.

Added optional option 'tmpDir' which will be passed to CacheSwap.

Default value is os.tmpdir()